### PR TITLE
Create Flappy Bird game with Vite and TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# flappy-bird
+# Flappy Bird — Primitive Edition
+
+A TypeScript + Vite implementation of the classic Flappy Bird game using only primitive Canvas shapes for rendering. The rendering pipeline is structured to make it easy to swap in animated sprite sheets in the future.
+
+## Getting started
+
+```bash
+npm install
+npm run dev
+```
+
+Then open the printed URL (typically `http://localhost:5173`) in your browser.
+
+## Gameplay
+
+- Tap/click or press <kbd>Space</kbd>/<kbd>Arrow Up</kbd> to flap.
+- Avoid the pipes and the ground to survive.
+- Your best score is tracked locally per session.
+
+## Testing
+
+Unit tests cover the physics helpers that drive the game loop.
+
+```bash
+npm test
+```
+
+## Build
+
+```bash
+npm run build
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Flappy Bird (Primitive)</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+        background: #0a192f;
+        color: #e6f1ff;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      #app {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 1rem;
+        padding: 1rem;
+      }
+      canvas {
+        max-width: 100%;
+        border-radius: 16px;
+        box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4);
+        background: linear-gradient(180deg, #56ccf2 0%, #2f80ed 100%);
+      }
+      button {
+        border: none;
+        background: #f2994a;
+        color: #0a192f;
+        padding: 0.75rem 1.5rem;
+        border-radius: 999px;
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+      }
+      button:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 8px 20px rgba(242, 153, 74, 0.45);
+      }
+      button:active {
+        transform: translateY(0);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "flappy-bird",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "nanoid": "^5.0.7"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0",
+    "vitest": "^1.1.0"
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,23 @@
+export const CANVAS_WIDTH = 480;
+export const CANVAS_HEIGHT = 640;
+
+export const BIRD_X = CANVAS_WIDTH * 0.3;
+export const BIRD_RADIUS = 18;
+export const INITIAL_BIRD_Y = CANVAS_HEIGHT / 2;
+
+export const GRAVITY = 0.45;
+export const FLAP_STRENGTH = -7.5;
+export const TERMINAL_VELOCITY = 11;
+
+export const PIPE_WIDTH = 80;
+export const PIPE_GAP = 160;
+export const PIPE_INTERVAL = 1400; // ms
+export const PIPE_SPEED = 2.75;
+
+export const GROUND_HEIGHT = 80;
+export const SKY_GRADIENT = ['#56ccf2', '#2f80ed'];
+
+export const BACKGROUND_HILLS = [
+  { color: 'rgba(255,255,255,0.15)', height: 100, speed: 0.25 },
+  { color: 'rgba(0,0,0,0.15)', height: 120, speed: 0.35 }
+];

--- a/src/game.ts
+++ b/src/game.ts
@@ -1,0 +1,160 @@
+import {
+  CANVAS_HEIGHT,
+  CANVAS_WIDTH,
+  GRAVITY,
+  PIPE_INTERVAL,
+  PIPE_SPEED
+} from './config';
+import {
+  advancePipes,
+  applyGravity,
+  clampVelocity,
+  createBird,
+  createPipe,
+  detectCollision,
+  filterVisiblePipes,
+  flapBird
+} from './physics';
+import { render } from './renderer';
+import type { Bird, GameState, Pipe } from './types';
+
+export class FlappyBirdGame {
+  private canvas: HTMLCanvasElement;
+  private ctx: CanvasRenderingContext2D;
+  private bird: Bird;
+  private pipes: Pipe[] = [];
+  private gameState: GameState = { status: 'idle', score: 0, highScore: 0 };
+  private scoredPipes = new Set<string>();
+  private lastTimestamp = 0;
+  private pipeTimer = 0;
+  private animationFrame: number | null = null;
+  private backgroundOffset = 0;
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.canvas = canvas;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      throw new Error('Canvas 2D context is not supported in this environment.');
+    }
+    this.ctx = ctx;
+    this.canvas.width = CANVAS_WIDTH;
+    this.canvas.height = CANVAS_HEIGHT;
+    this.bird = createBird({ width: CANVAS_WIDTH, height: CANVAS_HEIGHT });
+
+    this.bindEvents();
+    this.draw();
+  }
+
+  private bindEvents() {
+    const flap = () => {
+      if (this.gameState.status === 'over') {
+        this.reset();
+        this.start();
+        return;
+      }
+      if (this.gameState.status === 'idle') {
+        this.start();
+      }
+      if (this.gameState.status === 'running') {
+        this.bird = flapBird(this.bird);
+      }
+    };
+
+    this.canvas.addEventListener('pointerdown', flap);
+    window.addEventListener('keydown', (event) => {
+      if (event.code === 'Space' || event.code === 'ArrowUp') {
+        event.preventDefault();
+        flap();
+      }
+    });
+  }
+
+  private reset() {
+    this.bird = createBird({ width: CANVAS_WIDTH, height: CANVAS_HEIGHT });
+    this.pipes = [];
+    this.pipeTimer = 0;
+    this.backgroundOffset = 0;
+    this.scoredPipes.clear();
+    this.gameState = {
+      status: 'idle',
+      score: 0,
+      highScore: this.gameState.highScore
+    };
+  }
+
+  private start() {
+    if (this.gameState.status === 'running') return;
+    this.gameState.status = 'running';
+    this.lastTimestamp = performance.now();
+    this.loop(this.lastTimestamp);
+  }
+
+  private loop = (timestamp: number) => {
+    const deltaMs = timestamp - this.lastTimestamp;
+    const dt = deltaMs / (1000 / 60); // convert to frames
+    this.lastTimestamp = timestamp;
+
+    if (this.gameState.status === 'running') {
+      this.update(dt, deltaMs);
+    }
+
+    this.draw();
+    this.animationFrame = requestAnimationFrame(this.loop);
+  };
+
+  private update(dt: number, deltaMs: number) {
+    this.pipeTimer += deltaMs;
+
+    if (this.pipeTimer > PIPE_INTERVAL) {
+      this.pipes.push(createPipe({ width: CANVAS_WIDTH, height: CANVAS_HEIGHT }));
+      this.pipeTimer = 0;
+    }
+
+    this.pipes = advancePipes(this.pipes, PIPE_SPEED, dt);
+    this.pipes = filterVisiblePipes(this.pipes);
+
+    this.bird = applyGravity(this.bird, GRAVITY, dt);
+    this.bird.velocity = clampVelocity(this.bird.velocity);
+
+    if (detectCollision(this.bird, this.pipes, { width: CANVAS_WIDTH, height: CANVAS_HEIGHT })) {
+      this.endGame();
+      return;
+    }
+
+    this.updateScore();
+    this.backgroundOffset = (this.backgroundOffset + PIPE_SPEED * dt) % CANVAS_WIDTH;
+  }
+
+  private updateScore() {
+    for (const pipe of this.pipes) {
+      if (pipe.x + pipe.width < this.bird.x && !this.scoredPipes.has(pipe.id)) {
+        this.scoredPipes.add(pipe.id);
+        this.gameState.score += 1;
+      }
+    }
+    if (this.gameState.score > this.gameState.highScore) {
+      this.gameState.highScore = this.gameState.score;
+    }
+  }
+
+  private endGame() {
+    this.gameState.status = 'over';
+    if (this.animationFrame) {
+      cancelAnimationFrame(this.animationFrame);
+      this.animationFrame = null;
+    }
+    this.draw();
+  }
+
+  private draw() {
+    render(
+      this.ctx,
+      this.bird,
+      this.pipes,
+      this.gameState.score,
+      this.gameState.highScore,
+      this.gameState.status,
+      this.backgroundOffset
+    );
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,53 @@
+import './style.css';
+import { CANVAS_HEIGHT, CANVAS_WIDTH } from './config';
+import { FlappyBirdGame } from './game';
+
+const root = document.querySelector<HTMLDivElement>('#app');
+if (!root) {
+  throw new Error('Root element not found');
+}
+
+const title = document.createElement('h1');
+title.textContent = 'Flappy Bird — Primitive Edition';
+title.style.margin = '0';
+title.style.fontSize = '1.75rem';
+title.style.textAlign = 'center';
+
+const description = document.createElement('p');
+description.innerHTML =
+  'Click, tap or press <kbd>Space</kbd> / <kbd>↑</kbd> to flap. Primitive shapes are used now, but the rendering pipeline is ready for animated sprites later.';
+description.style.maxWidth = '480px';
+description.style.textAlign = 'center';
+description.style.color = 'rgba(255,255,255,0.85)';
+description.style.lineHeight = '1.5';
+
+const canvas = document.createElement('canvas');
+canvas.width = CANVAS_WIDTH;
+canvas.height = CANVAS_HEIGHT;
+canvas.style.maxWidth = 'min(90vw, 480px)';
+canvas.style.touchAction = 'manipulation';
+canvas.style.background = 'transparent';
+
+const restartButton = document.createElement('button');
+restartButton.textContent = 'Restart';
+restartButton.addEventListener('click', () => {
+  window.location.reload();
+});
+
+root.append(title, description, canvas, restartButton);
+
+// Attach stylesheet for kbd tags
+const style = document.createElement('style');
+style.textContent = `
+  kbd {
+    display: inline-block;
+    padding: 0.15rem 0.4rem;
+    border-radius: 0.35rem;
+    background: rgba(255,255,255,0.15);
+    border: 1px solid rgba(255,255,255,0.35);
+    font-size: 0.9rem;
+  }
+`;
+document.head.appendChild(style);
+
+new FlappyBirdGame(canvas);

--- a/src/physics.test.ts
+++ b/src/physics.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  applyGravity,
+  clampVelocity,
+  createBird,
+  createPipe,
+  detectCollision,
+  flapBird
+} from './physics';
+import { CANVAS_HEIGHT, CANVAS_WIDTH, FLAP_STRENGTH, TERMINAL_VELOCITY } from './config';
+
+describe('clampVelocity', () => {
+  it('limits velocity to terminal velocity', () => {
+    expect(clampVelocity(TERMINAL_VELOCITY + 10)).toBe(TERMINAL_VELOCITY);
+    expect(clampVelocity(-TERMINAL_VELOCITY - 10)).toBe(-TERMINAL_VELOCITY);
+    expect(clampVelocity(5)).toBe(5);
+  });
+});
+
+describe('applyGravity', () => {
+  it('increases velocity over time', () => {
+    const bird = createBird({ width: CANVAS_WIDTH, height: CANVAS_HEIGHT });
+    const updated = applyGravity(bird, 1, 1);
+    expect(updated.velocity).toBeGreaterThan(bird.velocity);
+    expect(updated.y).toBeGreaterThan(bird.y);
+  });
+
+  it('respects dt multiplier', () => {
+    const bird = createBird({ width: CANVAS_WIDTH, height: CANVAS_HEIGHT });
+    const slow = applyGravity(bird, 1, 0.5);
+    const fast = applyGravity(bird, 1, 2);
+    expect(fast.velocity).toBeGreaterThan(slow.velocity);
+  });
+});
+
+describe('flapBird', () => {
+  it('applies flap strength instantly', () => {
+    const bird = createBird({ width: CANVAS_WIDTH, height: CANVAS_HEIGHT });
+    const flapped = flapBird(bird);
+    expect(flapped.velocity).toBe(FLAP_STRENGTH);
+  });
+});
+
+describe('createPipe', () => {
+  it('creates pipes within bounds', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    const pipe = createPipe({ width: CANVAS_WIDTH, height: CANVAS_HEIGHT });
+    expect(pipe.x).toBe(CANVAS_WIDTH);
+    expect(pipe.gapY).toBeGreaterThan(0);
+    expect(pipe.gapY).toBeLessThan(CANVAS_HEIGHT);
+    vi.restoreAllMocks();
+  });
+});
+
+describe('detectCollision', () => {
+  it('detects collision with pipe', () => {
+    const bird = createBird({ width: CANVAS_WIDTH, height: CANVAS_HEIGHT });
+    const pipe = createPipe({ width: CANVAS_WIDTH, height: CANVAS_HEIGHT });
+    pipe.x = bird.x;
+    pipe.gapY = bird.y + 100; // ensure top collision
+    const collided = detectCollision(bird, [pipe], { width: CANVAS_WIDTH, height: CANVAS_HEIGHT });
+    expect(collided).toBe(true);
+  });
+
+  it('returns false when clear', () => {
+    const bird = createBird({ width: CANVAS_WIDTH, height: CANVAS_HEIGHT });
+    const pipe = createPipe({ width: CANVAS_WIDTH, height: CANVAS_HEIGHT });
+    pipe.x = bird.x + 400;
+    const collided = detectCollision(bird, [pipe], { width: CANVAS_WIDTH, height: CANVAS_HEIGHT });
+    expect(collided).toBe(false);
+  });
+});

--- a/src/physics.ts
+++ b/src/physics.ts
@@ -1,0 +1,96 @@
+import { nanoid } from 'nanoid';
+import {
+  BIRD_RADIUS,
+  CANVAS_HEIGHT,
+  CANVAS_WIDTH,
+  FLAP_STRENGTH,
+  GROUND_HEIGHT,
+  PIPE_GAP,
+  PIPE_WIDTH,
+  TERMINAL_VELOCITY
+} from './config';
+import type { Bird, Dimensions, Pipe } from './types';
+
+export const clampVelocity = (velocity: number): number => {
+  if (velocity > TERMINAL_VELOCITY) return TERMINAL_VELOCITY;
+  if (velocity < -TERMINAL_VELOCITY) return -TERMINAL_VELOCITY;
+  return velocity;
+};
+
+export const createBird = (dimensions: Dimensions): Bird => ({
+  x: dimensions.width * 0.3,
+  y: dimensions.height / 2,
+  radius: BIRD_RADIUS,
+  velocity: 0
+});
+
+export const applyGravity = (bird: Bird, gravity: number, dt: number): Bird => ({
+  ...bird,
+  velocity: clampVelocity(bird.velocity + gravity * dt),
+  y: bird.y + bird.velocity * dt
+});
+
+export const flapBird = (bird: Bird): Bird => ({
+  ...bird,
+  velocity: FLAP_STRENGTH
+});
+
+export const createPipe = (
+  dimensions: Dimensions,
+  gap: number = PIPE_GAP,
+  width: number = PIPE_WIDTH
+): Pipe => {
+  const margin = 40;
+  const verticalSpace = dimensions.height - GROUND_HEIGHT - gap - margin * 2;
+  const gapY = margin + Math.random() * verticalSpace;
+
+  return {
+    id: nanoid(),
+    x: dimensions.width,
+    gapY,
+    width
+  };
+};
+
+export const movePipe = (pipe: Pipe, dx: number): Pipe => ({
+  ...pipe,
+  x: pipe.x - dx
+});
+
+export const filterVisiblePipes = (pipes: Pipe[]): Pipe[] =>
+  pipes.filter((pipe) => pipe.x + pipe.width > 0);
+
+export const hasBirdCollidedWithPipe = (bird: Bird, pipe: Pipe, dimensions: Dimensions): boolean => {
+  const halfGap = PIPE_GAP / 2;
+  const topPipeBottom = pipe.gapY - halfGap;
+  const bottomPipeTop = pipe.gapY + halfGap;
+
+  if (bird.x + bird.radius < pipe.x || bird.x - bird.radius > pipe.x + pipe.width) {
+    return false;
+  }
+
+  if (bird.y - bird.radius < topPipeBottom) {
+    return true;
+  }
+
+  if (bird.y + bird.radius > bottomPipeTop) {
+    return true;
+  }
+
+  return false;
+};
+
+export const hasBirdHitBounds = (bird: Bird, dimensions: Dimensions): boolean => {
+  if (bird.y - bird.radius < 0) return true;
+  if (bird.y + bird.radius > dimensions.height - GROUND_HEIGHT) return true;
+  return false;
+};
+
+export const detectCollision = (bird: Bird, pipes: Pipe[], dimensions: Dimensions): boolean => {
+  if (hasBirdHitBounds(bird, dimensions)) return true;
+  return pipes.some((pipe) => hasBirdCollidedWithPipe(bird, pipe, dimensions));
+};
+
+export const advancePipes = (pipes: Pipe[], speed: number, dt: number): Pipe[] =>
+  pipes.map((pipe) => movePipe(pipe, speed * dt));
+

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,0 +1,139 @@
+import {
+  BIRD_RADIUS,
+  CANVAS_HEIGHT,
+  CANVAS_WIDTH,
+  GROUND_HEIGHT,
+  PIPE_GAP
+} from './config';
+import type { Bird, Pipe } from './types';
+
+export interface RendererOptions {
+  ctx: CanvasRenderingContext2D;
+  backgroundOffset: number;
+}
+
+export const clearCanvas = (ctx: CanvasRenderingContext2D) => {
+  ctx.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+};
+
+const drawBackground = (ctx: CanvasRenderingContext2D, offset: number) => {
+  const gradient = ctx.createLinearGradient(0, 0, 0, CANVAS_HEIGHT);
+  gradient.addColorStop(0, '#56ccf2');
+  gradient.addColorStop(1, '#2f80ed');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+  ctx.fillStyle = 'rgba(255,255,255,0.45)';
+  const hillWidth = 240;
+  const hillHeight = 90;
+  const hillY = CANVAS_HEIGHT - GROUND_HEIGHT - hillHeight / 2;
+  for (let i = -2; i < 4; i++) {
+    const hillX = (i * hillWidth + offset * 0.2) % (hillWidth * 2);
+    ctx.beginPath();
+    ctx.ellipse(hillX, hillY, hillWidth, hillHeight, 0, 0, Math.PI, true);
+    ctx.fill();
+  }
+};
+
+const drawGround = (ctx: CanvasRenderingContext2D, offset: number) => {
+  ctx.fillStyle = '#825201';
+  ctx.fillRect(0, CANVAS_HEIGHT - GROUND_HEIGHT, CANVAS_WIDTH, GROUND_HEIGHT);
+
+  ctx.fillStyle = '#f2c94c';
+  const stripeWidth = 40;
+  for (let i = -1; i < CANVAS_WIDTH / stripeWidth + 2; i++) {
+    const x = (i * stripeWidth + offset) % (stripeWidth * 2);
+    ctx.fillRect(x, CANVAS_HEIGHT - GROUND_HEIGHT, stripeWidth, GROUND_HEIGHT);
+  }
+};
+
+const drawBird = (ctx: CanvasRenderingContext2D, bird: Bird, status: string) => {
+  ctx.save();
+  ctx.translate(bird.x, bird.y);
+  const rotation = Math.min(Math.PI / 4, Math.max(-Math.PI / 6, bird.velocity / 12));
+  ctx.rotate(rotation);
+
+  ctx.fillStyle = status === 'over' ? '#eb5757' : '#f2c94c';
+  ctx.beginPath();
+  ctx.ellipse(0, 0, BIRD_RADIUS + 6, BIRD_RADIUS, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.fillStyle = '#333333';
+  ctx.beginPath();
+  ctx.arc(BIRD_RADIUS / 2, -BIRD_RADIUS / 3, 4, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.fillStyle = '#f2994a';
+  ctx.beginPath();
+  ctx.moveTo(BIRD_RADIUS, 0);
+  ctx.lineTo(BIRD_RADIUS + 12, -4);
+  ctx.lineTo(BIRD_RADIUS, 4);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+};
+
+const drawPipe = (ctx: CanvasRenderingContext2D, pipe: Pipe) => {
+  const halfGap = PIPE_GAP / 2;
+  const topHeight = pipe.gapY - halfGap;
+  const bottomY = pipe.gapY + halfGap;
+  const bottomHeight = CANVAS_HEIGHT - bottomY - GROUND_HEIGHT;
+
+  ctx.fillStyle = '#6fcf97';
+  ctx.fillRect(pipe.x, 0, pipe.width, topHeight);
+  ctx.fillRect(pipe.x, bottomY, pipe.width, bottomHeight);
+
+  ctx.fillStyle = '#27ae60';
+  ctx.fillRect(pipe.x - 6, topHeight - 20, pipe.width + 12, 20);
+  ctx.fillRect(pipe.x - 6, bottomY, pipe.width + 12, 20);
+};
+
+const drawScoreboard = (
+  ctx: CanvasRenderingContext2D,
+  score: number,
+  highScore: number,
+  status: 'idle' | 'running' | 'over'
+) => {
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.35)';
+  ctx.fillRect(16, 16, 140, 56);
+
+  ctx.fillStyle = '#ffffff';
+  ctx.font = '20px "Segoe UI", sans-serif';
+  ctx.textAlign = 'start';
+  ctx.fillText(`Score: ${score}`, 28, 40);
+  ctx.fillText(`Best: ${highScore}`, 28, 64);
+
+  if (status === 'idle') {
+    ctx.textAlign = 'center';
+    ctx.font = '26px "Segoe UI", sans-serif';
+    ctx.fillText('Tap, click or space to start!', CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2);
+  }
+
+  if (status === 'over') {
+    ctx.textAlign = 'center';
+    ctx.font = '32px "Segoe UI", sans-serif';
+    ctx.fillStyle = '#ffffff';
+    ctx.fillText('Game Over', CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2 - 20);
+    ctx.font = '20px "Segoe UI", sans-serif';
+    ctx.fillText('Press space or tap to retry', CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2 + 16);
+  }
+
+  ctx.textAlign = 'start';
+};
+
+export const render = (
+  ctx: CanvasRenderingContext2D,
+  bird: Bird,
+  pipes: Pipe[],
+  score: number,
+  highScore: number,
+  status: 'idle' | 'running' | 'over',
+  backgroundOffset: number
+) => {
+  clearCanvas(ctx);
+  drawBackground(ctx, backgroundOffset);
+  pipes.forEach((pipe) => drawPipe(ctx, pipe));
+  drawGround(ctx, backgroundOffset * 1.5);
+  drawBird(ctx, bird, status);
+  drawScoreboard(ctx, score, highScore, status);
+};

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,21 @@
+:root {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #e6f1ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #0a192f;
+}
+
+h1 {
+  letter-spacing: 0.02em;
+}
+
+p {
+  margin: 0;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,24 @@
+export interface Bird {
+  x: number;
+  y: number;
+  radius: number;
+  velocity: number;
+}
+
+export interface Pipe {
+  id: string;
+  x: number;
+  gapY: number;
+  width: number;
+}
+
+export interface GameState {
+  status: 'idle' | 'running' | 'over';
+  score: number;
+  highScore: number;
+}
+
+export interface Dimensions {
+  width: number;
+  height: number;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "skipLibCheck": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom'
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a TypeScript + Vite project for a primitive Flappy Bird clone using canvas rendering
- implement the game loop, physics helpers, and renderer using simple shapes with hooks for future sprite upgrades
- add unit tests that cover the reusable physics utilities driving bird movement and collision detection

## Testing
- npm test *(fails: dependencies could not be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d81deb83188331bb8829384e49a90f