### PR TITLE
Fix jitter in ground stripe animation

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -41,8 +41,11 @@ const drawGround = (ctx: CanvasRenderingContext2D, offset: number) => {
 
   ctx.fillStyle = '#f2c94c';
   const stripeWidth = 40;
+  const totalWidth = stripeWidth * 2;
+  const normalizedOffset = ((offset % totalWidth) + totalWidth) % totalWidth;
+
   for (let i = -1; i < CANVAS_WIDTH / stripeWidth + 2; i++) {
-    const x = (i * stripeWidth + offset) % (stripeWidth * 2);
+    const x = i * stripeWidth - normalizedOffset;
     ctx.fillRect(x, CANVAS_HEIGHT - GROUND_HEIGHT, stripeWidth, GROUND_HEIGHT);
   }
 };


### PR DESCRIPTION
## Summary
- normalize the ground stripe offset calculation to scroll smoothly without visible jumps

## Testing
- npm test -- --run *(fails: vitest requests installing jsdom interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68d8299b47f08331bf3db7ca839c049b