### PR TITLE
Set up GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        env:
+          GITHUB_PAGES: 'true'
+        run: npm run build
+
+      - name: Upload build output
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-node_modules
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A TypeScript + Vite implementation of the classic Flappy Bird game using only pr
 
 ## Play online
 
-The latest build is automatically deployed to GitHub Pages — play it here: https://<your-github-username>.github.io/flappy-bird/
+The latest build is automatically deployed to GitHub Pages — play it here: https://sergeypogorelov1993.github.io/flappy-bird/
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A TypeScript + Vite implementation of the classic Flappy Bird game using only primitive Canvas shapes for rendering. The rendering pipeline is structured to make it easy to swap in animated sprite sheets in the future.
 
+## Play online
+
+The latest build is automatically deployed to GitHub Pages — play it here: https://<your-github-username>.github.io/flappy-bird/
+
 ## Getting started
 
 ```bash
@@ -25,8 +29,10 @@ Unit tests cover the physics helpers that drive the game loop.
 npm test
 ```
 
-## Build
+## Build & deploy locally
 
 ```bash
 npm run build
 ```
+
+The GitHub Actions workflow (`.github/workflows/deploy.yml`) runs the same production build and publishes the `dist` folder to GitHub Pages.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,11 @@
 import { defineConfig } from 'vite';
 
-export default defineConfig({
+const repoBasePath = '/flappy-bird/';
+
+export default defineConfig(() => ({
+  base: process.env.GITHUB_PAGES === 'true' ? repoBasePath : '/',
   test: {
     globals: true,
     environment: 'jsdom'
   }
-});
+}));


### PR DESCRIPTION
## Summary
- configure Vite to use the repository path when building for GitHub Pages and ignore build artifacts
- add a GitHub Actions workflow that builds the project and publishes the dist bundle to Pages
- document the hosted build in the README with a link to the GitHub Pages site

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d831509ee48331b1f41c6a9a39d828